### PR TITLE
Update API to v2, added options, reportIp function, API error handling

### DIFF
--- a/src/AbuseIpDb.php
+++ b/src/AbuseIpDb.php
@@ -91,7 +91,7 @@ class AbuseIpDb
             'comment' => $comment
         ]);
 
-        return $result->data->abuseConfidentScore;
+        return $result->abuseConfidentScore;
     }
 
     /**

--- a/src/AbuseIpDb.php
+++ b/src/AbuseIpDb.php
@@ -5,8 +5,7 @@ namespace nickurt\AbuseIpDb;
 use \GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use \nickurt\AbuseIpDb\Exception\MalformedURLException;
-
-class AbuseIpDbException extends \Exception{};
+use \nickurt\AbuseIpDb\Exception\AbuseIpDbException;
 
 class AbuseIpDb
 {

--- a/src/AbuseIpDb.php
+++ b/src/AbuseIpDb.php
@@ -83,7 +83,7 @@ class AbuseIpDb
             $ip = $this->getIp();
         }
 
-        $ip = urlencode($ip);
+        $ip = urlencode($ip ?? $this->getIp());
 
         $result = $this->postResponseData('report', [
             'ip' => $ip,

--- a/src/Exception/AbuseIpDbException.php
+++ b/src/Exception/AbuseIpDbException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace nickurt\AbuseIpDb\Exception;
+
+class AbuseIpDbException extends \RuntimeException
+{
+}


### PR DESCRIPTION
- Updated API from V1 to V2
- added option cache_ttl - setCacheTTL to set the cache expiry in seconds (default 10s as before)
- added option spam_threshold - setSpamThreshold to set a threshold for abuse confidence score (default 100%)
- optional parameter to pass the IP to the function `IsSpamIp($ip = null)`
- added function to report an IP address: `reportIp($categories, $ip = null, $comment = '')`
- throw AbuseIpDbException on API error