### PR TITLE
Handle invalid json response from abuseipdb

### DIFF
--- a/src/AbuseIpDb.php
+++ b/src/AbuseIpDb.php
@@ -136,6 +136,10 @@ class AbuseIpDb
         }
 
         $output = json_decode($response->getBody());
+        
+        if (is_null($output)) {
+            throw new AbuseIpDbException('abuseipdb returned an invalid json response: "' . $response->getBody() . '".');
+        }
 
         if (property_exists($output, 'errors')) {
             throw new AbuseIpDbException(implode(', ', array_map(function ($error) {
@@ -273,7 +277,11 @@ class AbuseIpDb
             $response = $e->getResponse();
         }
 
-        $output = json_decode($response->getBody());
+        $output = json_decode($response->getBody());        
+        
+        if (is_null($output)) {
+            throw new AbuseIpDbException('abuseipdb returned an invalid json response: "' . $response->getBody() . '".');
+        }
 
         if (property_exists($output, 'errors')) {
             throw new AbuseIpDbException(implode(', ', array_map(function ($error) {


### PR DESCRIPTION
The script sometimes throws an ErrorException _First parameter must either be an object or the name of an existing class_ on checking property_exists($output, 'errors') on line #275.

The `$output` variable in those cases was null.

To prevent this ErrorException for an invalid response, catch it and thrown an AbuseIpDbException.